### PR TITLE
Changed year of PandaX-4T UL label

### DIFF
--- a/data/result_metadata.toml
+++ b/data/result_metadata.toml
@@ -213,7 +213,7 @@ delimiter = " "
 
 ["WIMPSI_PandaX-4T_2021_2107.13438"]
 description = "2021 Spin-independent result from PandaX-4T commisioning run"
-label="PandaX-4T (2023)"
+label="PandaX-4T (2021)"
 header = ["wimp_mass","upper_limit"]
 provenance = "collaboration"
 plot_color = "salmon"


### PR DESCRIPTION
Changed label from PandaX-4T (2023) -> PandaX-4T (2021) since [the PRL paper](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.127.261802) was published on 23 December, 2021.

![image](https://github.com/user-attachments/assets/75720a1f-9ca8-4140-b22b-aeb270339f75)